### PR TITLE
Adiciona botao de modo de gravação

### DIFF
--- a/Animacoes_neopixel.c
+++ b/Animacoes_neopixel.c
@@ -130,6 +130,9 @@ int main() {
         {
             gpio_put(GPIO_LED,false);
         }
+        if (caracter_press == '*'){
+            rom_reset_usb_boot(0, 0);
+        }
         busy_wait_us(500000);
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(Animacoes_neopixel
         hardware_pio
         hardware_timer
         hardware_clocks
+        pico_bootrom
         )
 
 pico_add_extra_outputs(Animacoes_neopixel)


### PR DESCRIPTION
Quando apertar no * o RP2040 entra no modo de gravação. Como se clicasse no bootsel e reset da BitDogLab.